### PR TITLE
Redirect from esyfo-info-frontend to meroppfolging-frontend

### DIFF
--- a/.github/workflows/deploy-redirect-dev.yaml
+++ b/.github/workflows/deploy-redirect-dev.yaml
@@ -15,6 +15,5 @@ jobs:
       - name: Deploy redirect ingress to dev-gcp
         uses: nais/deploy/actions/deploy@v2
         env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-gcp
           RESOURCE: nais/redirect-dev.yaml

--- a/.github/workflows/deploy-redirect-dev.yaml
+++ b/.github/workflows/deploy-redirect-dev.yaml
@@ -10,6 +10,8 @@ jobs:
   deploy:
     name: deploy redirect ingress to dev
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v3
       - name: Deploy redirect ingress to dev-gcp

--- a/.github/workflows/deploy-redirect-dev.yaml
+++ b/.github/workflows/deploy-redirect-dev.yaml
@@ -1,0 +1,20 @@
+name: Deploy redirect ingress to dev
+on:
+  push:
+    paths:
+      - 'nais/redirect-dev.yaml'
+      - '.github/workflows/deploy-redirect**'
+    branches:
+      - '**'
+jobs:
+  deploy:
+    name: deploy redirect ingress to dev
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Deploy redirect ingress to dev-gcp
+        uses: nais/deploy/actions/deploy@v2
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: dev-gcp
+          RESOURCE: nais/redirect-dev.yaml

--- a/.github/workflows/deploy-redirect-prod.yaml
+++ b/.github/workflows/deploy-redirect-prod.yaml
@@ -10,6 +10,8 @@ jobs:
   deploy:
     name: deploy redirect ingress to prod
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v3
       - name: Deploy redirect ingress to prod-gcp

--- a/.github/workflows/deploy-redirect-prod.yaml
+++ b/.github/workflows/deploy-redirect-prod.yaml
@@ -15,6 +15,5 @@ jobs:
       - name: Deploy redirect ingress to prod-gcp
         uses: nais/deploy/actions/deploy@v2
         env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: prod-gcp
           RESOURCE: nais/redirect-prod.yaml

--- a/.github/workflows/deploy-redirect-prod.yaml
+++ b/.github/workflows/deploy-redirect-prod.yaml
@@ -1,0 +1,20 @@
+name: Deploy redirect ingress to prod
+on:
+  push:
+    paths:
+      - 'nais/redirect-prod.yaml'
+      - '.github/workflows/deploy-redirect**'
+    branches:
+      - 'main'
+jobs:
+  deploy:
+    name: deploy redirect ingress to prod
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Deploy redirect ingress to prod-gcp
+        uses: nais/deploy/actions/deploy@v2
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-gcp
+          RESOURCE: nais/redirect-prod.yaml

--- a/nais/redirect-dev.yaml
+++ b/nais/redirect-dev.yaml
@@ -21,4 +21,3 @@ spec:
                 name: meroppfolging-frontend
                 port:
                   number: 80
----

--- a/nais/redirect-dev.yaml
+++ b/nais/redirect-dev.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: https://www.ekstern.dev.nav.no/syk/meroppfolging/snart-slutt-pa-sykepengene
+  labels:
+    app: meroppfolging-frontend
+    team: team-esyfo
+  name: esyfo-info-frontend-redirect
+  namespace: team-esyfo
+spec:
+  ingressClassName: nais-ingress-external
+  rules:
+    - host: www.ekstern.dev.nav.no
+      http:
+        paths:
+          - path: /syk/info/snart-slutt-pa-sykepengene(/|$)(.*)?
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: meroppfolging-frontend
+                port:
+                  number: 80
+---

--- a/nais/redirect-prod.yaml
+++ b/nais/redirect-prod.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: https://www.nav.no/syk/meroppfolging/snart-slutt-pa-sykepengene
+  labels:
+    app: meroppfolging-frontend
+    team: team-esyfo
+  name: esyfo-info-frontend-redirect
+  namespace: team-esyfo
+spec:
+  ingressClassName: nais-ingress-external
+  rules:
+    - host: www.nav.no
+      http:
+        paths:
+          - path: /syk/info/snart-slutt-pa-sykepengene(/|$)(.*)?
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: meroppfolging-frontend
+                port:
+                  number: 80


### PR DESCRIPTION
- Redirecter `www.nav.no/syk/info/snart-slutt-pa-sykepengene` til `https://www.nav.no/syk/meroppfolging/snart-slutt-pa-sykepengene`
- Redirecter `www.ekstern.dev.nav.no/syk/info/snart-slutt-pa-sykepengene` til `https://www.ekstern.dev.nav.no/syk/meroppfolging/snart-slutt-pa-sykepengene`

Er deployet til dev, så kan testes der. Har slettet esyfo-info-frontend fra dev.