### PR TITLE
Show no access information for certain users

### DIFF
--- a/src/mocks/data/fixtures/statusPilotDtoFixtures.ts
+++ b/src/mocks/data/fixtures/statusPilotDtoFixtures.ts
@@ -3,16 +3,23 @@ import { StatusPilotDTO } from '@/server/services/schemas/statusSchema'
 export const pilotIkkeSvart: StatusPilotDTO = {
   isPilot: true,
   response: null,
+  hasAccessToSenOppfolging: true,
 }
 
-// TODO: Brukes ikke, bruke eller slette?
-export const pilotSvartTilbakeHosArbeidsgiver: StatusPilotDTO = {
+export const pilotIkkeSvartAndShouldNotHaveAccess: StatusPilotDTO = {
   isPilot: true,
+  response: null,
+  hasAccessToSenOppfolging: false,
+}
+
+export const pilotSvartFortsattSykOgTrengerOppfolging: StatusPilotDTO = {
+  isPilot: true,
+  hasAccessToSenOppfolging: true,
   response: [
     {
       questionType: 'FREMTIDIG_SITUASJON',
       questionText: 'Hva tenker du om fremtiden?',
-      answerType: 'TILBAKE_HOS_ARBEIDSGIVER',
+      answerType: 'FORTSATT_SYK',
       answerText: 'syk',
     },
     {
@@ -24,9 +31,9 @@ export const pilotSvartTilbakeHosArbeidsgiver: StatusPilotDTO = {
   ],
 }
 
-// TODO: Brukes ikke, bruke eller slette?
-export const pilotTrengerIkkeOppfolging: StatusPilotDTO = {
+export const pilotSvartTilbakeHosArbeidsgiverOgTrengerIkkeOppfolging: StatusPilotDTO = {
   isPilot: true,
+  hasAccessToSenOppfolging: true,
   response: [
     {
       questionType: 'FREMTIDIG_SITUASJON',

--- a/src/mocks/testScenarioUtils.ts
+++ b/src/mocks/testScenarioUtils.ts
@@ -45,9 +45,11 @@ export const getStatusPilotDTOFixture = (): StatusPilotDTO => {
   const storedAnswer: string | null = window.sessionStorage.getItem(SESSION_STORAGE_PILOT_ANSWERS_KEY)
   if (storedAnswer) {
     const formAnswer: FormRequest = JSON.parse(storedAnswer)
+
     return {
       isPilot: true,
       response: formAnswer.senOppfolgingFormV2,
+      hasAccessToSenOppfolging: true,
     }
   }
   return statusPilotDtoFixtures.pilotIkkeSvart

--- a/src/pages/404.page.tsx
+++ b/src/pages/404.page.tsx
@@ -1,0 +1,33 @@
+import { ReactElement } from 'react'
+import { BodyShort, Box, Button, Heading, List, Page, VStack } from '@navikt/ds-react'
+import Link from 'next/link'
+
+function Custom404(): ReactElement {
+  return (
+    <Page.Block as="main" width="xl" gutters>
+      <Box paddingBlock="20 16" data-aksel-template="404-v2">
+        <VStack gap="16">
+          <VStack gap="12" align="start">
+            <div>
+              <Heading level="1" size="large" spacing>
+                Beklager, vi fant ikke siden
+              </Heading>
+              <BodyShort>Denne siden kan være slettet eller flyttet, eller det er en feil i lenken.</BodyShort>
+              <List>
+                <List.Item>Bruk gjerne søket eller menyen</List.Item>
+                <List.Item>
+                  <Link href="#">Gå til forsiden</Link>
+                </List.Item>
+              </List>
+            </div>
+            <Button as="a" href="https://www.nav.no/minside">
+              Gå til Min side
+            </Button>
+          </VStack>
+        </VStack>
+      </Box>
+    </Page.Block>
+  )
+}
+
+export default Custom404

--- a/src/pages/snart-slutt-pa-sykepengene/index.test.tsx
+++ b/src/pages/snart-slutt-pa-sykepengene/index.test.tsx
@@ -3,7 +3,12 @@ import { describe, expect, it } from 'vitest'
 import { render, screen } from '@/test/testUtils'
 import { testServer } from '@/mocks/testServer'
 import { trpcMsw } from '@/utils/trpc'
-import { pilotIkkeSvart } from '@/mocks/data/fixtures/statusPilotDtoFixtures'
+import {
+  pilotIkkeSvart,
+  pilotIkkeSvartAndShouldNotHaveAccess,
+  pilotSvartFortsattSykOgTrengerOppfolging,
+  pilotSvartTilbakeHosArbeidsgiverOgTrengerIkkeOppfolging,
+} from '@/mocks/data/fixtures/statusPilotDtoFixtures'
 import SnartSlutt from '@/pages/snart-slutt-pa-sykepengene/index.page'
 
 describe('SnartSlutt', () => {
@@ -17,5 +22,44 @@ describe('SnartSlutt', () => {
     render(<SnartSlutt />)
 
     expect(await screen.findByRole('heading', { name: 'Vil du ha hjelp fra oss?', level: 1 })).toBeInTheDocument()
+  })
+
+  it('should display heading for no access screen if user should not have access to sen oppfølging solution', async () => {
+    testServer.use(
+      trpcMsw.statusPilot.query(async (_req, res, ctx) => {
+        return res(ctx.status(200), ctx.data(pilotIkkeSvartAndShouldNotHaveAccess))
+      }),
+    )
+
+    render(<SnartSlutt />)
+
+    expect(
+      await screen.findByRole('heading', { name: 'Beklager, du kan ikke svare på dette skjemaet nå.', level: 1 }),
+    ).toBeInTheDocument()
+  })
+
+  it('should dipslay display receipt with certain headings if user has responded fortsatt syk og trenger oppfølging', async () => {
+    testServer.use(
+      trpcMsw.statusPilot.query(async (_req, res, ctx) => {
+        return res(ctx.status(200), ctx.data(pilotSvartFortsattSykOgTrengerOppfolging))
+      }),
+    )
+
+    render(<SnartSlutt />)
+
+    expect(await screen.findByRole('heading', { name: 'Vi tar kontakt med deg', level: 1 })).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: 'Når du er for syk til å jobbe', level: 2 })).toBeInTheDocument()
+  })
+
+  it('should dipslay display receipt with correct heading if user has responded trenger ikke oppfølging', async () => {
+    testServer.use(
+      trpcMsw.statusPilot.query(async (_req, res, ctx) => {
+        return res(ctx.status(200), ctx.data(pilotSvartTilbakeHosArbeidsgiverOgTrengerIkkeOppfolging))
+      }),
+    )
+
+    render(<SnartSlutt />)
+
+    expect(await screen.findByRole('heading', { name: 'Det kan hende du hører fra oss', level: 1 })).toBeInTheDocument()
   })
 })

--- a/src/pilot/components/LandingPage/LandingPilot.tsx
+++ b/src/pilot/components/LandingPage/LandingPilot.tsx
@@ -4,21 +4,26 @@ import { VStack } from '@navikt/ds-react'
 import PageContainer from '@/pilot/components/containers/PageContainer'
 import SenOppfolging from '@/pilot/components/SenOppfolging/SenOppfolging'
 import Receipt from '@/pilot/components/Receipt/Receipt'
-import { PilotStatus } from '@/server/services/schemas/statusSchema'
+import { StatusPilotDTO } from '@/server/services/schemas/statusSchema'
+import NoAccessInformation from '@/pilot/components/LandingPage/NoAccessInformation'
 
-function LandingContent({ response }: { response: PilotStatus['response'] }): ReactElement {
-  if (response === null) {
+function LandingContent({ status }: { status: StatusPilotDTO }): ReactElement {
+  if (!status.hasAccessToSenOppfolging) {
+    return <NoAccessInformation />
+  }
+
+  if (status.response === null) {
     return <SenOppfolging />
   } else {
-    return <Receipt response={response} />
+    return <Receipt response={status.response} />
   }
 }
 
-function LandingPilot({ status }: { status: PilotStatus }): ReactElement {
+function LandingPilot({ status }: { status: StatusPilotDTO }): ReactElement {
   return (
     <PageContainer className="bg-bg-subtle">
       <VStack gap="6" className="max-w-4xl bg-bg-default px-4 py-8 md:p-12">
-        <LandingContent response={status.response} />
+        <LandingContent status={status} />
       </VStack>
     </PageContainer>
   )

--- a/src/pilot/components/LandingPage/NoAccessInformation.tsx
+++ b/src/pilot/components/LandingPage/NoAccessInformation.tsx
@@ -1,0 +1,41 @@
+import { ReactElement } from 'react'
+import { BodyShort, Box, Button, Heading } from '@navikt/ds-react'
+import { logger } from '@navikt/next-logger'
+import Image from 'next/image'
+
+import { NAV_PHONE_NUMBER } from '@/constants/appConstants'
+import WriteToUsLink from '@/pilot/components/UI/WriteToUsLink'
+import { useLogAmplitudeEvent } from '@/libs/amplitude/amplitude'
+import pageErrorDad from '@/components/ErrorBoundary/Images/error-page-dad.svg'
+
+function NoAccessInformation(): ReactElement {
+  const logMessage = "User visited SenOppfolging page, but does not have access. Showing 'You cannot access form' page."
+  logger.warn(logMessage)
+  useLogAmplitudeEvent({ eventName: 'besøk' }, { info: logMessage })
+
+  return (
+    <Box className="md:pt-20 md:pb-16 flex flex-col gap-8 items-start">
+      <div className="flex flex-col md:flex-row gap-6 max-md:items-center">
+        <Image width={202} height={240} src={pageErrorDad} alt="" className="max-md:h-[170px] h-[240px] w-[202px] " />
+        <div>
+          <Heading level="1" size="large" spacing>
+            Beklager, du kan ikke svare på dette skjemaet nå.
+          </Heading>
+          <BodyShort spacing>
+            Dette skjemaet er ikke åpnet for deg. Skjemaet skal være åpnet dersom du er sykmeldt og nærmer deg slutten
+            på perioden du kan motta sykepenger, og du har fått et varsel som lenker hit.
+          </BodyShort>
+          <BodyShort>
+            Hvis du mener det har skjedd en feil, prøv igjen senere. Hvis feilen vedvarer, ta kontakt med oss på tlf.{' '}
+            {NAV_PHONE_NUMBER} eller på <WriteToUsLink /> (åpner i ny fane).
+          </BodyShort>
+        </div>
+      </div>
+      <Button as="a" href="https://www.nav.no/minside">
+        Gå til Min side
+      </Button>
+    </Box>
+  )
+}
+
+export default NoAccessInformation

--- a/src/server/services/schemas/statusSchema.ts
+++ b/src/server/services/schemas/statusSchema.ts
@@ -7,8 +7,8 @@ import { ResponseStatus } from './meroppfolgingSchema'
 export const PilotStatusSchema = z.object({
   isPilot: z.literal(true),
   response: z.union([FormSchema, z.literal(null)]),
+  hasAccessToSenOppfolging: z.boolean(),
 })
-export type PilotStatus = z.infer<typeof PilotStatusSchema>
 
 export const NotPilotStatusSchema = z.object({
   isPilot: z.literal(false),


### PR DESCRIPTION
Show no access information for users that should not have access. The concern now is users that have not received a notification but still visits the URL.

Also add a 404 page for users that visits a random URL.

https://trello.com/c/SdkQDFwD/1322-meroppfolging-frontend-vis-404-side-for-sykmeldte-som-bes%C3%B8ker-skjema-landingssiden-og-ikke-har-f%C3%A5tt-varsel

Co-authored-by: Luan Tran <luan.tran@nav.no>