### PR TITLE
Catch amplitude logger errors

### DIFF
--- a/src/libs/amplitude/amplitude.ts
+++ b/src/libs/amplitude/amplitude.ts
@@ -1,11 +1,12 @@
 import { useEffect, useRef } from 'react'
 import { getAmplitudeInstance } from '@navikt/nav-dekoratoren-moduler'
+import { logger as pinoLogger } from '@navikt/next-logger'
 
 import { isLocalOrDemo } from '@/constants/envs'
 
 import { AmplitudeTaxonomyEvents } from './events'
 
-const logger = getAmplitudeInstance('dekoratoren')
+const dekoratorenAmplitudeLogger = getAmplitudeInstance('dekoratoren')
 
 const infoProperties = { team: 'eSyfo', app: 'meroppfolging-frontend' }
 
@@ -59,9 +60,14 @@ export async function logAmplitudeEvent(
     return
   }
 
-  await logger(eventType, {
-    ...eventProperties,
-  })
+  try {
+    // This can throw an error (rejected promise), therefore try-catch
+    await dekoratorenAmplitudeLogger(eventType, {
+      ...eventProperties,
+    })
+  } catch (error) {
+    pinoLogger.error(`Could not log event to Amplitude. Message: ${(error as Error)?.message}`)
+  }
 }
 
 export async function logCustomAmplitudeEvent(event: string, extraData?: Record<string, unknown>): Promise<void> {
@@ -75,5 +81,5 @@ export async function logCustomAmplitudeEvent(event: string, extraData?: Record<
     return
   }
 
-  await logger(event, eventProperties)
+  await dekoratorenAmplitudeLogger(event, eventProperties)
 }

--- a/src/libs/amplitude/amplitude.ts
+++ b/src/libs/amplitude/amplitude.ts
@@ -51,23 +51,7 @@ export async function logAmplitudeEvent(
 ): Promise<void> {
   const { eventType, eventProperties } = taxonomyToAmplitudeEvent(event, extraData)
 
-  if (isLocalOrDemo) {
-    console.log('Amplitude event: ' + eventType)
-    if (eventProperties) {
-      console.log(eventProperties)
-    }
-
-    return
-  }
-
-  try {
-    // This can throw an error (rejected promise), therefore try-catch
-    await dekoratorenAmplitudeLogger(eventType, {
-      ...eventProperties,
-    })
-  } catch (error) {
-    pinoLogger.error(`Could not log event to Amplitude. Message: ${(error as Error)?.message}`)
-  }
+  await logAmplitudeEventUsingDekoratorenInstance(eventType, eventProperties)
 }
 
 export async function logCustomAmplitudeEvent(event: string, extraData?: Record<string, unknown>): Promise<void> {
@@ -76,10 +60,22 @@ export async function logCustomAmplitudeEvent(event: string, extraData?: Record<
     ...extraData,
   }
 
+  await logAmplitudeEventUsingDekoratorenInstance(event, eventProperties)
+}
+
+async function logAmplitudeEventUsingDekoratorenInstance(
+  event: string,
+  eventProperties: Record<string, unknown>,
+): Promise<void> {
   if (isLocalOrDemo) {
-    console.log(`Custom Amplitude event: ${event}`, eventProperties)
+    console.log(`Amplitude event: ${event}, eventProperties:\n${(JSON.stringify(eventProperties ?? {}), null, 2)}`)
     return
   }
 
-  await dekoratorenAmplitudeLogger(event, eventProperties)
+  try {
+    // This can throw an error (rejected promise), therefore try-catch
+    await dekoratorenAmplitudeLogger(event, eventProperties)
+  } catch (error) {
+    pinoLogger.error(`Could not log event to Amplitude. Message: ${(error as Error)?.message}`)
+  }
 }


### PR DESCRIPTION
There are some exceptions in grafana from the amplitude logger call. They stem from promise rejection in nav-dekoratoren-moduler, see https://github.com/navikt/nav-dekoratoren-moduler/blob/f907024c2613bd602c805652275b810082465a33/src/csr/functions/amplitude.ts#L46.