### PR TITLE
docs: oppdater README med repo-spesifikk dokumentasjon

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,10 +14,10 @@ Start with one primary agent. If a task spans multiple domains, either switch pr
 ## Commands
 
 ```sh
-npm run dev
-npm run lint
-npm test
-npx tsc --noEmit
+pnpm run dev
+pnpm run lint
+pnpm test
+pnpm exec tsc --noEmit
 ```
 
 ## Defaults

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 * @navikt/team-esyfo
 
-# Set empty owners on package.json and package-lock.json to avoid that github adds team-esyfo as reviewer on all automergeable prs from Dependabot
+# Set empty owners on package.json and pnpm-lock.yaml to avoid that github adds team-esyfo as reviewer on all automergeable prs from Dependabot
 package.json
-package-lock.json
+pnpm-lock.yaml

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ flowchart LR
     F --> D[NAV-dekoratøren]
     F -->|TokenX OBO| M[meroppfolging-backend]
     F -->|TokenX OBO| S[sykepengedager-informasjon]
-    F --> L[@navikt/next-logger]
+    F --> L["@navikt/next-logger"]
     F --> T[Grafana Faro]
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,38 +1,115 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+# Meroppfølging frontendapp
 
-## Getting Started
+[![CI](https://github.com/navikt/meroppfolging-frontend/actions/workflows/build-and-deploy.yaml/badge.svg)](https://github.com/navikt/meroppfolging-frontend/actions/workflows/build-and-deploy.yaml)
+[![Next.js 15](https://img.shields.io/badge/Next.js-15-000000?logo=next.js)](https://nextjs.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![Biome](https://img.shields.io/badge/Biome-lint%20%26%20format-60A5FA?logo=biome)](https://biomejs.dev/)
+[![Vitest](https://img.shields.io/badge/Vitest-test-6E9F18?logo=vitest&logoColor=white)](https://vitest.dev/)
 
-First, run the development server:
+Meroppfølging frontendapp er en Next.js-app for personer som er sykmeldt og nærmer seg slutten på sykepengeperioden. Appen viser maksdato for sykepenger, samler inn svar om situasjonen videre og lar brukeren be om oppfølging fra Nav.
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
+## Formål
+
+Appen er laget for privatpersoner som har fått tilgang til skjemaet fordi sykepengene snart tar slutt.
+
+Brukeren kan:
+
+- se informasjon om når sykepengene tar slutt
+- svare på spørsmål om situasjonen når sykepengene er brukt opp
+- be om oppfølging fra en veileder
+- se kvittering hvis svar allerede er sendt inn
+
+Hvis brukeren ikke har tilgang, viser appen en egen informasjonsside i stedet for skjemaet.
+
+## Miljøer
+
+- [Dev](https://www.ekstern.dev.nav.no/syk/meroppfolging/snart-slutt-pa-sykepengene)
+- [Prod](https://www.nav.no/syk/meroppfolging/snart-slutt-pa-sykepengene)
+
+Appen ligger bak base path `/syk/meroppfolging`. Eldre lenker under `/syk/info/snart-slutt-pa-sykepengene` videresendes til dagens URL i både dev og prod.
+
+## Teknologier
+
+- Next.js 15 med App Router og React 18
+- TypeScript 5
+- Aksel v8 (`@navikt/ds-react`) og Tailwind CSS v3
+- `@navikt/oasis` for validering av IdPorten-token og TokenX-utveksling
+- `@navikt/next-logger` for serverlogger
+- Grafana Faro for klienttelemetri når `NEXT_PUBLIC_TELEMETRY_URL` er satt
+- Zod for validering av miljøvariabler og API-data
+- Vitest, Testing Library og `vitest-axe` for tester
+- Biome for linting og formattering
+- Lefthook for Git hooks
+- NAIS og Docker `standalone`-build for deploy
+
+## Arkitektur
+
+```mermaid
+flowchart LR
+    U[Bruker] --> F[meroppfolging-frontend]
+    F --> I[IdPorten sidecar + OASIS]
+    F --> D[NAV-dekoratøren]
+    F -->|TokenX OBO| M[meroppfolging-backend]
+    F -->|TokenX OBO| S[sykepengedager-informasjon]
+    F --> L[@navikt/next-logger]
+    F --> T[Grafana Faro]
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Kort fortalt:
 
-You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
+- Appen rendrer skjermbildene i Next.js og bruker NAV-dekoratøren for header og footer.
+- IdPorten-sidecar i NAIS håndterer innlogging. Appen validerer token med OASIS.
+- Før kall til backendene veksler appen IdPorten-token til TokenX på vegne av brukeren.
+- I `local` og `demo` brukes mock-data for status, maksdato og innsending.
 
-[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.ts`.
+## Backend-referanser
 
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
+### [meroppfolging-backend](https://github.com/navikt/meroppfolging-backend)
 
-This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
+Lagrer og henter brukerens svar i flyten for sen oppfølging.
 
-## Learn More
+- **GET** `/api/v2/senoppfolging/status`
+- **POST** `/api/v2/senoppfolging/submitform`
 
-To learn more about Next.js, take a look at the following resources:
+### [sykepengedager-informasjon](https://github.com/navikt/sykepengedager-informasjon)
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+Leverer maksdato for sykepenger som vises i landingssiden og kvitteringen.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
+- **GET** `/api/v1/sykepenger/maxdate?isoformat=true`
 
-## Deploy on Vercel
+`flexjar-backend` er satt opp i NAIS-manifestet med `accessPolicy` og miljøvariabler, men brukes ikke i applikasjonskoden per i dag.
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+## Kom i gang lokalt
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+Forutsetninger:
+
+- Node.js 24
+- pnpm 10
+
+Slik jobber du lokalt:
+
+1. Installer avhengigheter med pnpm.
+2. Se oppdatert liste over scripts med `pnpm run`.
+3. Start appen med repoets dev-script.
+4. Åpne [http://localhost:3000/syk/meroppfolging/snart-slutt-pa-sykepengene](http://localhost:3000/syk/meroppfolging/snart-slutt-pa-sykepengene).
+
+Nyttig å vite:
+
+- `NEXT_PUBLIC_BASE_PATH` er `/syk/meroppfolging`.
+- Påkrevde miljøvariabler valideres i `src/constants/envs.ts`.
+- Testoppsettet bruker `.env.test`.
+- Git hooks kjører Biome på staged filer før commit og `tsc --noEmit` før push.
+
+## Drift og deploy
+
+- CI og deploy styres av GitHub Actions-workflowen `build-and-deploy.yaml`.
+- Appen deployes til NAIS i `dev` og `prod`.
+- Helseendepunkter finnes på `/api/isAlive` og `/api/isReady` under base path.
+- `POST /api/logger` videresender klientlogger via `@navikt/next-logger`.
+- Filer i `public/` lastes opp til NAV CDN av en egen workflow.
+
+## For Nav-ansatte
+
+- Team: `team-esyfo`
+- Kodeeiere: `@navikt/team-esyfo`
+- Kontakt: [#esyfo på Slack](https://nav-it.slack.com/archives/C012X796B4L)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,24 @@
 # Meroppfølging frontendapp
 
 [![CI](https://github.com/navikt/meroppfolging-frontend/actions/workflows/build-and-deploy.yaml/badge.svg)](https://github.com/navikt/meroppfolging-frontend/actions/workflows/build-and-deploy.yaml)
-[![Next.js 15](https://img.shields.io/badge/Next.js-15-000000?logo=next.js)](https://nextjs.org/)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![Next.js](https://img.shields.io/badge/Next.js-000000?logo=next.js)](https://nextjs.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Biome](https://img.shields.io/badge/Biome-lint%20%26%20format-60A5FA?logo=biome)](https://biomejs.dev/)
 [![Vitest](https://img.shields.io/badge/Vitest-test-6E9F18?logo=vitest&logoColor=white)](https://vitest.dev/)
 
 Meroppfølging frontendapp er en Next.js-app for personer som er sykmeldt og nærmer seg slutten på sykepengeperioden. Appen viser maksdato for sykepenger, samler inn svar om situasjonen videre og lar brukeren be om oppfølging fra Nav.
 
-## Formål
+## Miljøer
+
+🚀 [Produksjon](https://www.nav.no/syk/meroppfolging/snart-slutt-pa-sykepengene)
+
+🛠️ [Utvikling](https://www.ekstern.dev.nav.no/syk/meroppfolging/snart-slutt-pa-sykepengene)
+
+🎬 [Demo](https://demo.ekstern.dev.nav.no/syk/meroppfolging/snart-slutt-pa-sykepengene)
+
+Appen ligger bak base path `/syk/meroppfolging`. Eldre lenker under `/syk/info/snart-slutt-pa-sykepengene` videresendes til dagens URL i både dev og prod.
+
+## Formålet med appen
 
 Appen er laget for privatpersoner som har fått tilgang til skjemaet fordi sykepengene snart tar slutt.
 
@@ -20,27 +30,6 @@ Brukeren kan:
 - se kvittering hvis svar allerede er sendt inn
 
 Hvis brukeren ikke har tilgang, viser appen en egen informasjonsside i stedet for skjemaet.
-
-## Miljøer
-
-- [Dev](https://www.ekstern.dev.nav.no/syk/meroppfolging/snart-slutt-pa-sykepengene)
-- [Prod](https://www.nav.no/syk/meroppfolging/snart-slutt-pa-sykepengene)
-
-Appen ligger bak base path `/syk/meroppfolging`. Eldre lenker under `/syk/info/snart-slutt-pa-sykepengene` videresendes til dagens URL i både dev og prod.
-
-## Teknologier
-
-- Next.js 15 med App Router og React 18
-- TypeScript 5
-- Aksel v8 (`@navikt/ds-react`) og Tailwind CSS v3
-- `@navikt/oasis` for validering av IdPorten-token og TokenX-utveksling
-- `@navikt/next-logger` for serverlogger
-- Grafana Faro for klienttelemetri når `NEXT_PUBLIC_TELEMETRY_URL` er satt
-- Zod for validering av miljøvariabler og API-data
-- Vitest, Testing Library og `vitest-axe` for tester
-- Biome for linting og formattering
-- Lefthook for Git hooks
-- NAIS og Docker `standalone`-build for deploy
 
 ## Arkitektur
 
@@ -55,13 +44,6 @@ flowchart LR
     F --> T[Grafana Faro]
 ```
 
-Kort fortalt:
-
-- Appen rendrer skjermbildene i Next.js og bruker NAV-dekoratøren for header og footer.
-- IdPorten-sidecar i NAIS håndterer innlogging. Appen validerer token med OASIS.
-- Før kall til backendene veksler appen IdPorten-token til TokenX på vegne av brukeren.
-- I `local` og `demo` brukes mock-data for status, maksdato og innsending.
-
 ## Backend-referanser
 
 ### [meroppfolging-backend](https://github.com/navikt/meroppfolging-backend)
@@ -75,41 +57,20 @@ Lagrer og henter brukerens svar i flyten for sen oppfølging.
 
 Leverer maksdato for sykepenger som vises i landingssiden og kvitteringen.
 
-- **GET** `/api/v1/sykepenger/maxdate?isoformat=true`
+- **GET** `/api/v1/sykepenger/maxdate` (`?isoformat=true` legges til i appkoden)
 
 `flexjar-backend` er satt opp i NAIS-manifestet med `accessPolicy` og miljøvariabler, men brukes ikke i applikasjonskoden per i dag.
 
-## Kom i gang lokalt
+## Utvikling (kjøre lokalt)
 
-Forutsetninger:
+For å komme i gang med å bygge og kjøre appen, se vår [Wiki for frontendapper](https://navikt.github.io/team-esyfo/utvikling/frontend/).
 
-- Node.js 24
-- pnpm 10
-
-Slik jobber du lokalt:
-
-1. Installer avhengigheter med pnpm.
-2. Se oppdatert liste over scripts med `pnpm run`.
-3. Start appen med repoets dev-script.
-4. Åpne [http://localhost:3000/syk/meroppfolging/snart-slutt-pa-sykepengene](http://localhost:3000/syk/meroppfolging/snart-slutt-pa-sykepengene).
-
-Nyttig å vite:
-
-- `NEXT_PUBLIC_BASE_PATH` er `/syk/meroppfolging`.
-- Påkrevde miljøvariabler valideres i `src/constants/envs.ts`.
-- Testoppsettet bruker `.env.test`.
-- Git hooks kjører Biome på staged filer før commit og `tsc --noEmit` før push.
-
-## Drift og deploy
-
-- CI og deploy styres av GitHub Actions-workflowen `build-and-deploy.yaml`.
-- Appen deployes til NAIS i `dev` og `prod`.
-- Helseendepunkter finnes på `/api/isAlive` og `/api/isReady` under base path.
-- `POST /api/logger` videresender klientlogger via `@navikt/next-logger`.
-- Filer i `public/` lastes opp til NAV CDN av en egen workflow.
+**basePath**[^basepath] `/syk/meroppfolging`
 
 ## For Nav-ansatte
 
-- Team: `team-esyfo`
-- Kodeeiere: `@navikt/team-esyfo`
-- Kontakt: [#esyfo på Slack](https://nav-it.slack.com/archives/C012X796B4L)
+Interne henvendelser kan sendes via Slack i kanalen [#esyfo](https://nav-it.slack.com/archives/C012X796B4L).
+
+---
+
+[^basepath]: `basePath`-verdien settes i Next.js-konfigurasjonen i `next.config.js` og angir URL-prefikset som hele appen lever under.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Meroppfølging frontendapp er en Next.js-app for personer som er sykmeldt og næ
 
 🎬 [Demo](https://demo.ekstern.dev.nav.no/syk/meroppfolging/snart-slutt-pa-sykepengene)
 
-Appen ligger bak base path `/syk/meroppfolging`. Eldre lenker under `/syk/info/snart-slutt-pa-sykepengene` videresendes til dagens URL i både dev og prod.
+Appen ligger bak **basePath**[^basepath]. Eldre lenker under `/syk/info/snart-slutt-pa-sykepengene` videresendes til dagens URL i både dev og prod.
 
 ## Formålet med appen
 


### PR DESCRIPTION
## Beskrivelse

Oppdaterer repo-dokumentasjonen slik at README beskriver faktisk oppsett, arkitektur og utviklingsflyt i meroppfolging-frontend. I tillegg er repo-metadata justert til pnpm-baserte kommandoer og korrekt lockfilnavn.

## Endringer

- `README.md`: fullstendig omskrevet fra standard Next.js-mal til repo-spesifikk dokumentasjon med badges, formål, miljølenker, Mermaid-diagram, backend-referanser, utviklingsoppsett og kontaktinfo
- `AGENTS.md`: oppdatert kommandoeksempler fra `npm` til `pnpm`
- `CODEOWNERS`: erstattet `package-lock.json` med `pnpm-lock.yaml`
- Mermaid-diagrammet er justert slik at nodenavn med `@` er korrekt sitert

## Issue

Closes #1743

## Verifisering

Ikke kjørt (kun dokumentasjonsendringer)

## Sjekkliste

- [ ] Koden kompilerer og linter uten feil
- [ ] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)