### PR TITLE
chore(pnpm): oppgrader til pnpm 11.3.0

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,6 @@
 [tools]
 node = "24"
-pnpm = "10"
+pnpm = "11"
 
 [tasks.install]
 description = "Install dependencies (cached)"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "node": "24"
   },
-  "packageManager": "pnpm@10.29.2",
+  "packageManager": "pnpm@11.3.0",
   "scripts": {
     "dev": "next dev | pino-pretty",
     "build": "next build",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+allowBuilds:
+  esbuild: true
+  lefthook: false
+  protobufjs: false
+  sharp: true
+
+minimumReleaseAge: 4320
+blockExoticSubdeps: true


### PR DESCRIPTION
## Beskrivelse

Oppgraderer repoet fra pnpm 10 til pnpm 11.3.0. Dette dekker package manager-pinning, mise-versjon og pnpm 11 build-script-policy.

## Endringer

- `package.json`: setter `packageManager` til `pnpm@11.3.0`
- `.mise.toml`: oppdaterer pnpm tool-versjon til major 11
- `pnpm-workspace.yaml`: legger til eksplisitt pnpm 11-konfig for `allowBuilds`, `minimumReleaseAge` og `blockExoticSubdeps`
- `.npmrc`: vurdert som kompatibel med pnpm 11 og beholdt uendret
- `pnpm-lock.yaml`: uendret etter install med pnpm 11.3.0; lockfile v9 er fortsatt konsistent

## Issue

Closes #1803

## Verifisering

- `corepack pnpm install`: OK
- `corepack pnpm install --frozen-lockfile`: OK
- `CI=1 corepack pnpm test`: OK
- `corepack pnpm run build`: OK
- `corepack pnpm run check`: feiler på eksisterende formatteringsavvik i `.github/skills/prototype/scripts/helper.js` og `.github/skills/prototype/scripts/server.js`; disse er ikke endret i denne PR-en

## Sjekkliste

- [ ] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)